### PR TITLE
First attempt at adding Workbench installer capabilities

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -36,7 +36,7 @@ func newSetup(setupOpts setupOpts) error {
 	}
 
 	// Workbench installation
-	workbenchInstalled, err := workbench.VerifyWorkbench()
+	workbenchInstalled := workbench.VerifyWorkbench()
 	// If Workbench is not detected then prompt to install
 	if !workbenchInstalled {
 		installWorkbenchChoice, err := workbench.WorkbenchInstallPrompt()
@@ -48,6 +48,8 @@ func newSetup(setupOpts setupOpts) error {
 			if err != nil {
 				return fmt.Errorf("issue installing Workbench: %w", err)
 			}
+		} else {
+			log.Fatal("Workbench installation is required to continue")
 		}
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -29,16 +29,26 @@ func newSetup(setupOpts setupOpts) error {
 
 	var WBConfig config.WBConfig
 
-	// Workbench installation
-	_, err := workbench.VerifyWorkbench()
-	if err != nil {
-		return err
-	}
-
 	// Determine OS
 	osType, err := os.DetectOS()
 	if err != nil {
 		return err
+	}
+
+	// Workbench installation
+	workbenchInstalled, err := workbench.VerifyWorkbench()
+	// If Workbench is not detected then prompt to install
+	if !workbenchInstalled {
+		installWorkbenchChoice, err := workbench.WorkbenchInstallPrompt()
+		if err != nil {
+			return fmt.Errorf("issue selecting Workbench installation: %w", err)
+		}
+		if installWorkbenchChoice {
+			err := workbench.DownloadAndInstallWorkbench(osType)
+			if err != nil {
+				return fmt.Errorf("issue installing Workbench: %w", err)
+			}
+		}
 	}
 
 	// Languages

--- a/internal/system/command.go
+++ b/internal/system/command.go
@@ -4,11 +4,15 @@ import (
 	"bufio"
 	"fmt"
 	"os/exec"
+	"time"
 )
 
 // Runs a command in the terminal and streams the output
 func RunCommand(command string) error {
 	fmt.Println("Running command: " + command)
+	// sleep for 3 seconds to allow the user to read the command
+	time.Sleep(3 * time.Second)
+
 	cmd := exec.Command("/bin/sh", "-c", command)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/system/command.go
+++ b/internal/system/command.go
@@ -1,8 +1,8 @@
 package system
 
 import (
-	"bufio"
 	"fmt"
+	"os"
 	"os/exec"
 	"time"
 )
@@ -14,23 +14,14 @@ func RunCommand(command string) error {
 	time.Sleep(3 * time.Second)
 
 	cmd := exec.Command("/bin/sh", "-c", command)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	scanner := bufio.NewScanner(stdout)
-	err = cmd.Start()
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("issue running command: %w", err)
 	}
-	for scanner.Scan() {
-		fmt.Println(scanner.Text())
-	}
-	if scanner.Err() != nil {
-		cmd.Process.Kill()
-		cmd.Wait()
-		return fmt.Errorf("issue running command: %w", scanner.Err())
-	}
-	cmd.Wait()
+
 	return nil
 }

--- a/internal/system/command.go
+++ b/internal/system/command.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 )
 
+// Runs a command in the terminal and streams the output
 func RunCommand(command string) error {
 	fmt.Println("Running command: " + command)
 	cmd := exec.Command("/bin/sh", "-c", command)

--- a/internal/system/command.go
+++ b/internal/system/command.go
@@ -1,0 +1,31 @@
+package system
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+)
+
+func RunCommand(command string) error {
+	fmt.Println("Running command: " + command)
+	cmd := exec.Command("/bin/sh", "-c", command)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(stdout)
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("issue running command: %w", err)
+	}
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+	if scanner.Err() != nil {
+		cmd.Process.Kill()
+		cmd.Wait()
+		return fmt.Errorf("issue running command: %w", scanner.Err())
+	}
+	cmd.Wait()
+	return nil
+}

--- a/internal/workbench/download.go
+++ b/internal/workbench/download.go
@@ -1,0 +1,49 @@
+package workbench
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Create a temporary file and download the Workbench installer to it.
+func (installerInfo *InstallerInfo) DownloadWorkbench() (string, error) {
+
+	url := installerInfo.URL
+	name := installerInfo.BaseName
+
+	// Create the file
+	tmpFile, err := os.CreateTemp("", name)
+	if err != nil {
+		return tmpFile.Name(), err
+	}
+	defer tmpFile.Close()
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, url, nil)
+	if err != nil {
+		return "", errors.New("error creating request")
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return "", errors.New("error downloading Workbench installer")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", errors.New("error retrieving Workbench installer")
+	}
+
+	// Writer the body to file
+	_, err = io.Copy(tmpFile, res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return tmpFile.Name(), nil
+}

--- a/internal/workbench/install.go
+++ b/internal/workbench/install.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dpastoor/wbi/internal/system"
 )
 
-// Define JSON structure
+// InstallerInfo contains the information needed to download and install Workbench
 type InstallerInfo struct {
 	BaseName string `json:"basename"`
 	URL      string `json:"url"`
@@ -19,6 +19,7 @@ type InstallerInfo struct {
 	Label    string `json:"label"`
 }
 
+// OperatingSystems contains the installer information for each supported operating system
 type OperatingSystems struct {
 	Bionic  InstallerInfo `json:"bionic"`
 	Jammy   InstallerInfo `json:"jammy"`
@@ -26,26 +27,32 @@ type OperatingSystems struct {
 	Redhat8 InstallerInfo `json:"rhel8"`
 }
 
+// Installer contains the installer information for a product
 type Installer struct {
 	Installer OperatingSystems `json:"installer"`
 }
 
+// ProductType contains the installer for each product type
 type ProductType struct {
 	Server Installer `json:"server"`
 }
 
+// Category contains information for stable and preview product types
 type Category struct {
 	Stable ProductType `json:"stable"`
 }
 
+// Product contains information for each RStudio product
 type Product struct {
 	Pro Category `json:"pro"`
 }
 
+// RStudio contains product information
 type RStudio struct {
 	Rstudio Product `json:"rstudio"`
 }
 
+// Retrieves JSON data from Posit, downloads the Workbench installer, and installs Workbench
 func DownloadAndInstallWorkbench(osType string) error {
 	// Retrieve JSON data
 	rstudio, err := RetrieveWorkbenchInstallerInfo()
@@ -70,6 +77,7 @@ func DownloadAndInstallWorkbench(osType string) error {
 	return nil
 }
 
+// Installs Gdebi Core
 func InstallGdebiCore() error {
 	gdebiCoreCommand := "sudo apt-get install -y gdebi-core"
 	err := system.RunCommand(gdebiCoreCommand)
@@ -81,6 +89,7 @@ func InstallGdebiCore() error {
 	return nil
 }
 
+// Upgrades Apt
 func UpgradeApt() error {
 	aptUpgradeCommand := "sudo apt-get update"
 	err := system.RunCommand(aptUpgradeCommand)
@@ -92,6 +101,7 @@ func UpgradeApt() error {
 	return nil
 }
 
+// Installs Workbench in a certain way based on the operating system
 func InstallWorkbench(filepath string, osType string) error {
 	// Install gdebi-core if an Ubuntu system
 	if osType == "ubuntu22" || osType == "ubuntu20" || osType == "ubuntu18" {
@@ -120,6 +130,7 @@ func InstallWorkbench(filepath string, osType string) error {
 	return nil
 }
 
+// Creates the proper command to install Workbench based on the operating system
 func RetrieveInstallCommandForWorkbench(filepath string, os string) (string, error) {
 	switch os {
 	case "ubuntu22", "ubuntu20", "ubuntu18":
@@ -131,6 +142,7 @@ func RetrieveInstallCommandForWorkbench(filepath string, os string) (string, err
 	}
 }
 
+// Pulls out the installer information from the JSON data based on the operating system
 func (r *RStudio) GetInstallerInfo(os string) (InstallerInfo, error) {
 	switch os {
 	case "ubuntu18", "ubuntu20":
@@ -146,6 +158,7 @@ func (r *RStudio) GetInstallerInfo(os string) (InstallerInfo, error) {
 	}
 }
 
+// Retrieves JSON data from Posit
 func RetrieveWorkbenchInstallerInfo() (RStudio, error) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,

--- a/internal/workbench/install.go
+++ b/internal/workbench/install.go
@@ -1,0 +1,172 @@
+package workbench
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dpastoor/wbi/internal/system"
+)
+
+// Define JSON structure
+type InstallerInfo struct {
+	BaseName string `json:"basename"`
+	URL      string `json:"url"`
+	Version  string `json:"version"`
+	Label    string `json:"label"`
+}
+
+type OperatingSystems struct {
+	Bionic  InstallerInfo `json:"bionic"`
+	Jammy   InstallerInfo `json:"jammy"`
+	Redhat7 InstallerInfo `json:"redhat7_64"`
+	Redhat8 InstallerInfo `json:"rhel8"`
+}
+
+type Installer struct {
+	Installer OperatingSystems `json:"installer"`
+}
+
+type ProductType struct {
+	Server Installer `json:"server"`
+}
+
+type Category struct {
+	Stable ProductType `json:"stable"`
+}
+
+type Product struct {
+	Pro Category `json:"pro"`
+}
+
+type RStudio struct {
+	Rstudio Product `json:"rstudio"`
+}
+
+func DownloadAndInstallWorkbench(osType string) error {
+	// Retrieve JSON data
+	rstudio, err := RetrieveWorkbenchInstallerInfo()
+	if err != nil {
+		return fmt.Errorf("RetrieveWorkbenchInstallerInfo: %w", err)
+	}
+	// Retrieve installer info
+	installerInfo, err := rstudio.GetInstallerInfo(osType)
+	if err != nil {
+		return fmt.Errorf("GetInstallerInfo: %w", err)
+	}
+	// Download installer
+	filepath, err := installerInfo.DownloadWorkbench()
+	if err != nil {
+		return fmt.Errorf("DownloadWorkbench: %w", err)
+	}
+	// Install Workbench
+	err = InstallWorkbench(filepath, osType)
+	if err != nil {
+		return fmt.Errorf("InstallWorkbench: %w", err)
+	}
+	return nil
+}
+
+func InstallGdebiCore() error {
+	gdebiCoreCommand := "sudo apt-get install -y gdebi-core"
+	err := system.RunCommand(gdebiCoreCommand)
+	if err != nil {
+		return fmt.Errorf("issue installing gdebi-core: %w", err)
+	}
+
+	fmt.Println("\ngdebi-core has been successfully installed!\n")
+	return nil
+}
+
+func UpgradeApt() error {
+	aptUpgradeCommand := "sudo apt-get update"
+	err := system.RunCommand(aptUpgradeCommand)
+	if err != nil {
+		return fmt.Errorf("issue upgrading apt: %w", err)
+	}
+
+	fmt.Println("\napt has been successfully upgraded!\n")
+	return nil
+}
+
+func InstallWorkbench(filepath string, osType string) error {
+	// Install gdebi-core if an Ubuntu system
+	if osType == "ubuntu22" || osType == "ubuntu20" || osType == "ubuntu18" {
+		AptErr := UpgradeApt()
+		if AptErr != nil {
+			return fmt.Errorf("UpgradeApt: %w", AptErr)
+		}
+
+		GdebiCoreErr := InstallGdebiCore()
+		if GdebiCoreErr != nil {
+			return fmt.Errorf("InstallGdebiCore: %w", GdebiCoreErr)
+		}
+	}
+
+	installCommand, err := RetrieveInstallCommandForWorkbench(filepath, osType)
+	if err != nil {
+		return fmt.Errorf("RetrieveInstallCommandForWorkbench: %w", err)
+	}
+
+	err = system.RunCommand(installCommand)
+	if err != nil {
+		return fmt.Errorf("issue installing Workbench: %w", err)
+	}
+
+	fmt.Println("\nWorkbench has been successfully installed!\n")
+	return nil
+}
+
+func RetrieveInstallCommandForWorkbench(filepath string, os string) (string, error) {
+	switch os {
+	case "ubuntu22", "ubuntu20", "ubuntu18":
+		return "sudo gdebi -n " + filepath, nil
+	case "redhat7", "redhat8":
+		return "sudo yum install -y " + filepath, nil
+	default:
+		return "", errors.New("operating system not supported")
+	}
+}
+
+func (r *RStudio) GetInstallerInfo(os string) (InstallerInfo, error) {
+	switch os {
+	case "ubuntu18", "ubuntu20":
+		return r.Rstudio.Pro.Stable.Server.Installer.Bionic, nil
+	case "ubuntu22":
+		return r.Rstudio.Pro.Stable.Server.Installer.Jammy, nil
+	case "redhat7":
+		return r.Rstudio.Pro.Stable.Server.Installer.Redhat7, nil
+	case "redhat8":
+		return r.Rstudio.Pro.Stable.Server.Installer.Redhat8, nil
+	default:
+		return InstallerInfo{}, errors.New("operating system not supported")
+	}
+}
+
+func RetrieveWorkbenchInstallerInfo() (RStudio, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, "https://www.rstudio.com/wp-content/downloads.json", nil)
+	if err != nil {
+		return RStudio{}, errors.New("error creating request")
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return RStudio{}, errors.New("error retrieving JSON data")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return RStudio{}, errors.New("error retrieving JSON data")
+	}
+	var rstudio RStudio
+	err = json.NewDecoder(res.Body).Decode(&rstudio)
+	if err != nil {
+		return RStudio{}, errors.New("error unmarshalling JSON data")
+	}
+	return rstudio, nil
+}

--- a/internal/workbench/install.go
+++ b/internal/workbench/install.go
@@ -11,6 +11,13 @@ import (
 	"github.com/dpastoor/wbi/internal/system"
 )
 
+const Ubuntu22 = "ubuntu22"
+const Ubuntu20 = "ubuntu20"
+const Ubuntu18 = "ubuntu18"
+
+const Redhat8 = "redhat8"
+const Redhat7 = "redhat7"
+
 // InstallerInfo contains the information needed to download and install Workbench
 type InstallerInfo struct {
 	BaseName string `json:"basename"`
@@ -104,7 +111,7 @@ func UpgradeApt() error {
 // Installs Workbench in a certain way based on the operating system
 func InstallWorkbench(filepath string, osType string) error {
 	// Install gdebi-core if an Ubuntu system
-	if osType == "ubuntu22" || osType == "ubuntu20" || osType == "ubuntu18" {
+	if osType == Ubuntu22 || osType == Ubuntu20 || osType == Ubuntu18 {
 		AptErr := UpgradeApt()
 		if AptErr != nil {
 			return fmt.Errorf("UpgradeApt: %w", AptErr)
@@ -133,9 +140,9 @@ func InstallWorkbench(filepath string, osType string) error {
 // Creates the proper command to install Workbench based on the operating system
 func RetrieveInstallCommandForWorkbench(filepath string, os string) (string, error) {
 	switch os {
-	case "ubuntu22", "ubuntu20", "ubuntu18":
+	case Ubuntu22, Ubuntu20, Ubuntu18:
 		return "sudo gdebi -n " + filepath, nil
-	case "redhat7", "redhat8":
+	case Redhat7, Redhat8:
 		return "sudo yum install -y " + filepath, nil
 	default:
 		return "", errors.New("operating system not supported")
@@ -145,13 +152,13 @@ func RetrieveInstallCommandForWorkbench(filepath string, os string) (string, err
 // Pulls out the installer information from the JSON data based on the operating system
 func (r *RStudio) GetInstallerInfo(os string) (InstallerInfo, error) {
 	switch os {
-	case "ubuntu18", "ubuntu20":
+	case Ubuntu18, Ubuntu20:
 		return r.Rstudio.Pro.Stable.Server.Installer.Bionic, nil
-	case "ubuntu22":
+	case Ubuntu22:
 		return r.Rstudio.Pro.Stable.Server.Installer.Jammy, nil
-	case "redhat7":
+	case Redhat7:
 		return r.Rstudio.Pro.Stable.Server.Installer.Redhat7, nil
-	case "redhat8":
+	case Redhat8:
 		return r.Rstudio.Pro.Stable.Server.Installer.Redhat8, nil
 	default:
 		return InstallerInfo{}, errors.New("operating system not supported")

--- a/internal/workbench/prompt.go
+++ b/internal/workbench/prompt.go
@@ -1,0 +1,20 @@
+package workbench
+
+import (
+	"errors"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+// Prompt users if they would like to install Workbench
+func WorkbenchInstallPrompt() (bool, error) {
+	name := true
+	prompt := &survey.Confirm{
+		Message: "Workbench is required to be installed to continue. Would you like to install Workbench?",
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with the Workbench install prompt")
+	}
+	return name, nil
+}

--- a/internal/workbench/verify.go
+++ b/internal/workbench/verify.go
@@ -1,21 +1,18 @@
 package workbench
 
 import (
-	"errors"
 	"fmt"
 	"os/exec"
 )
 
-func VerifyWorkbench() (bool, error) {
-
+func VerifyWorkbench() bool {
 	cmd := exec.Command("/bin/sh", "-c", "sudo rstudio-server version")
 	stdout, err := cmd.Output()
 
 	if err != nil {
-		return false, errors.New("workbench installation not detected. Please install Workbench first by following the instructions at: https://docs.posit.co/rsw/installation/")
+		return false
+	} else {
+		fmt.Println("Workbench installation detected: ", string(stdout))
+		return true
 	}
-
-	fmt.Println("Workbench installation detected: ", string(stdout))
-	return true, nil
-
 }

--- a/internal/workbench/verify.go
+++ b/internal/workbench/verify.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 )
 
+// Checks if Workbench is installed
 func VerifyWorkbench() bool {
 	cmd := exec.Command("/bin/sh", "-c", "sudo rstudio-server version")
 	stdout, err := cmd.Output()

--- a/internal/workbench/verify.go
+++ b/internal/workbench/verify.go
@@ -6,16 +6,16 @@ import (
 	"os/exec"
 )
 
-func VerifyWorkbench() (string, error) {
+func VerifyWorkbench() (bool, error) {
 
 	cmd := exec.Command("/bin/sh", "-c", "sudo rstudio-server version")
 	stdout, err := cmd.Output()
 
 	if err != nil {
-		return "", errors.New("workbench installation not detected. Please install Workbench first by following the instructions at: https://docs.posit.co/rsw/installation/")
+		return false, errors.New("workbench installation not detected. Please install Workbench first by following the instructions at: https://docs.posit.co/rsw/installation/")
 	}
 
 	fmt.Println("Workbench installation detected: ", string(stdout))
-	return string(stdout), nil
+	return true, nil
 
 }


### PR DESCRIPTION
This is a first attempt at building out the feature described in: https://github.com/dpastoor/wbi/issues/7

It is structured so first it tries to detect Workbench. If Workbench is installed it skips the install step. If Workbench is not installed, it offers to install.

It grabs metadata from here: https://www.rstudio.com/wp-content/downloads.json and parses out the correct installer URL/name based on the detected OS. Then it downloads the correct installer into a tmp directory, runs any prerequisites (upgrades apt and installs gdebi-core if Ubuntu) and then installs Workbench.

I read that `http.Client{}` only needs to be defined once per app but was having trouble figuring out where in the app it goes so it can be used by various internal packages. Right now I created it in two spots so would like to consolidate.

Video below:

https://user-images.githubusercontent.com/180123/218196549-e44cb6f8-2b0d-4003-8c95-2fe59405bf1c.mp4

