### PR TITLE
Add config conversion

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -71,6 +71,7 @@ func newSetup(setupOpts setupOpts) error {
 			if err != nil {
 				return fmt.Errorf("issue selecting Python location for Jupyter: %w", err)
 			}
+			WBConfig.PythonConfig.JupyterPath = jupyterPythonTarget
 
 			if jupyterPythonTarget != "" {
 				err := jupyter.InstallJupyter(jupyterPythonTarget)
@@ -87,15 +88,15 @@ func newSetup(setupOpts setupOpts) error {
 		return fmt.Errorf("issue selecting if SSL is to be used: %w", err)
 	}
 	if useSSL {
-		sslCertPath, err := ssl.PromptSSLFilePath()
+		WBConfig.SSLConfig.CertPath, err = ssl.PromptSSLFilePath()
 		if err != nil {
 			return fmt.Errorf("issue with the provided SSL cert path: %w", err)
 		}
-		sslCertKeyPath, err := ssl.PromptSSLKeyFilePath()
+		WBConfig.SSLConfig.KeyPath, err = ssl.PromptSSLKeyFilePath()
 		if err != nil {
 			return fmt.Errorf("issue with the provided SSL cert key path: %w", err)
 		}
-		verifySSLCert := ssl.VerifySSLCertAndKey(sslCertPath, sslCertKeyPath)
+		verifySSLCert := ssl.VerifySSLCertAndKey(WBConfig.SSLConfig.CertPath, WBConfig.SSLConfig.KeyPath)
 		if verifySSLCert != nil {
 			return fmt.Errorf("could not verify the SSL cert: %w", err)
 		}
@@ -103,7 +104,7 @@ func newSetup(setupOpts setupOpts) error {
 	}
 
 	// Authentication
-	WBConfig.AuthType, err = authentication.PromptAndConvertAuthType()
+	WBConfig.AuthConfig.AuthType, err = authentication.PromptAndConvertAuthType()
 	if err != nil {
 		return fmt.Errorf("issue entering and converting AuthType: %w", err)
 	}
@@ -111,6 +112,9 @@ func newSetup(setupOpts setupOpts) error {
 	if AuthErr != nil {
 		return fmt.Errorf("issue handling authentication: %w", AuthErr)
 	}
+
+	// Write config to console
+	WBConfig.ConfigStructToText()
 
 	// Licensing
 	licenseKey, err := license.PromptLicense()

--- a/internal/authentication/prompt.go
+++ b/internal/authentication/prompt.go
@@ -55,9 +55,9 @@ func ConvertAuthType(authChoice string) (config.AuthType, error) {
 
 // Route an authentication choice to the proper prompts/information
 func HandleAuthChoice(WBConfig *config.WBConfig, targetOS string) error {
-	switch WBConfig.AuthType {
+	switch WBConfig.AuthConfig.AuthType {
 	case config.SAML:
-		err := HandleSAMLConfig(&WBConfig.SAMLConfig)
+		err := HandleSAMLConfig(&WBConfig.AuthConfig.SAMLConfig)
 		if err != nil {
 			return fmt.Errorf("HandleSAMLConfig: %w", err)
 		}
@@ -66,7 +66,7 @@ func HandleAuthChoice(WBConfig *config.WBConfig, targetOS string) error {
 	case config.OIDC:
 		fmt.Println("Setting up OpenID Connect based authentication is a 2 step process. First configure your OpenID provider with the steps outlined here to complete step 1: https://docs.posit.co/ide/server-pro/authenticating_users/openid_connect_authentication.html#configuring-your-openid-provider \n\n As you register Workbench in the IdP, save the client-id and client-secret. Follow the next step of prompts to configure Workbench to complete step 2.")
 
-		err := HandleOIDCConfig(&WBConfig.OIDCConfig)
+		err := HandleOIDCConfig(&WBConfig.AuthConfig.OIDCConfig)
 		if err != nil {
 			return fmt.Errorf("HandleOIDCConfig: %w", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,11 +17,15 @@ func (d AuthType) String() string {
 // WBConfig stores the entire workbench configuration
 type WBConfig struct {
 	SSLConfig    SSLConfig
-	AuthType     AuthType
 	RConfig      RConfig
 	PythonConfig PythonConfig
-	OIDCConfig   OIDCConfig
-	SAMLConfig   SAMLConfig
+	AuthConfig   AuthConfig
+}
+
+type AuthConfig struct {
+	AuthType   AuthType
+	OIDCConfig OIDCConfig
+	SAMLConfig SAMLConfig
 }
 
 type RConfig struct {
@@ -29,7 +33,8 @@ type RConfig struct {
 }
 
 type PythonConfig struct {
-	Paths []string
+	Paths       []string
+	JupyterPath string
 }
 
 // SSLConfig stores SSL config

--- a/internal/config/convert.go
+++ b/internal/config/convert.go
@@ -1,0 +1,50 @@
+package config
+
+import "fmt"
+
+func (WBConfig *WBConfig) ConfigStructToText() {
+	WBConfig.PythonConfig.PythonStructToText()
+	WBConfig.SSLConfig.SSLStructToText()
+	WBConfig.AuthConfig.AuthStructToText()
+}
+
+func (PythonConfig *PythonConfig) PythonStructToText() {
+	fmt.Println("\n=== Adding to config file: /etc/rstudio/jupyter.conf:")
+	fmt.Println("jupyter-exe=" + PythonConfig.JupyterPath)
+}
+
+func (SSLConfig *SSLConfig) SSLStructToText() {
+	fmt.Println("\n=== Adding to config file: /etc/rstudio/rserver.conf:")
+	fmt.Println("ssl-enabled=1")
+	fmt.Println("ssl-certificate=" + SSLConfig.CertPath)
+	fmt.Println("ssl-certificate-key=" + SSLConfig.KeyPath)
+}
+
+func (AuthConfig *AuthConfig) AuthStructToText() {
+	switch AuthConfig.AuthType {
+	case SAML:
+		AuthConfig.SAMLConfig.AuthSAMLStructToText()
+	case OIDC:
+		AuthConfig.OIDCConfig.AuthOIDCStructToText()
+	default:
+
+	}
+}
+
+func (SAMLConfig *SAMLConfig) AuthSAMLStructToText() {
+	fmt.Println("\n=== Adding to config file: /etc/rstudio/rserver.conf:")
+	fmt.Println("auth-saml=1")
+	fmt.Println("auth-saml-sp-attribute-username=" + SAMLConfig.AuthSamlSpAttributeUsername)
+	fmt.Println("auth-saml-metadata-url=" + SAMLConfig.AuthSamlMetadataURL)
+}
+
+func (OIDCConfig *OIDCConfig) AuthOIDCStructToText() {
+	fmt.Println("\n=== Adding to config file: /etc/rstudio/rserver.conf:")
+	fmt.Println("auth-openid=1")
+	fmt.Println("auth-openid-issuer=" + OIDCConfig.AuthOpenIDIssuer)
+	fmt.Println("auth-openid-username-claim=" + OIDCConfig.AuthOpenIDUsernameClaim)
+
+	fmt.Println("\n=== Adding to config file: /etc/rstudio/openid-client-secret:")
+	fmt.Println("client-id=" + OIDCConfig.ClientID)
+	fmt.Println("client-secret=" + OIDCConfig.ClientSecret)
+}

--- a/internal/config/print.go
+++ b/internal/config/print.go
@@ -2,24 +2,29 @@ package config
 
 import "fmt"
 
+// Prints the WBConfig configuration struct information to the console
 func (WBConfig *WBConfig) ConfigStructToText() {
 	WBConfig.PythonConfig.PythonStructToText()
 	WBConfig.SSLConfig.SSLStructToText()
 	WBConfig.AuthConfig.AuthStructToText()
+	fmt.Println("\n=== Please restart Workbench after making these changes")
 }
 
+// Prints the PythonConfig configuration struct information to the console
 func (PythonConfig *PythonConfig) PythonStructToText() {
-	fmt.Println("\n=== Adding to config file: /etc/rstudio/jupyter.conf:")
+	fmt.Println("\n=== Add to config file: /etc/rstudio/jupyter.conf:")
 	fmt.Println("jupyter-exe=" + PythonConfig.JupyterPath)
 }
 
+// Prints the SSLConfig configuration struct information to the console
 func (SSLConfig *SSLConfig) SSLStructToText() {
-	fmt.Println("\n=== Adding to config file: /etc/rstudio/rserver.conf:")
+	fmt.Println("\n=== Add to config file: /etc/rstudio/rserver.conf:")
 	fmt.Println("ssl-enabled=1")
 	fmt.Println("ssl-certificate=" + SSLConfig.CertPath)
 	fmt.Println("ssl-certificate-key=" + SSLConfig.KeyPath)
 }
 
+// Prints the AuthConfig configuration struct information to the console
 func (AuthConfig *AuthConfig) AuthStructToText() {
 	switch AuthConfig.AuthType {
 	case SAML:
@@ -31,20 +36,22 @@ func (AuthConfig *AuthConfig) AuthStructToText() {
 	}
 }
 
+// Prints the SAMLConfig configuration struct information to the console
 func (SAMLConfig *SAMLConfig) AuthSAMLStructToText() {
-	fmt.Println("\n=== Adding to config file: /etc/rstudio/rserver.conf:")
+	fmt.Println("\n=== Add to config file: /etc/rstudio/rserver.conf:")
 	fmt.Println("auth-saml=1")
 	fmt.Println("auth-saml-sp-attribute-username=" + SAMLConfig.AuthSamlSpAttributeUsername)
 	fmt.Println("auth-saml-metadata-url=" + SAMLConfig.AuthSamlMetadataURL)
 }
 
+// Prints the OIDCConfig configuration struct information to the console
 func (OIDCConfig *OIDCConfig) AuthOIDCStructToText() {
-	fmt.Println("\n=== Adding to config file: /etc/rstudio/rserver.conf:")
+	fmt.Println("\n=== Add to config file: /etc/rstudio/rserver.conf:")
 	fmt.Println("auth-openid=1")
 	fmt.Println("auth-openid-issuer=" + OIDCConfig.AuthOpenIDIssuer)
 	fmt.Println("auth-openid-username-claim=" + OIDCConfig.AuthOpenIDUsernameClaim)
 
-	fmt.Println("\n=== Adding to config file: /etc/rstudio/openid-client-secret:")
+	fmt.Println("\n=== Add to config file: /etc/rstudio/openid-client-secret:")
 	fmt.Println("client-id=" + OIDCConfig.ClientID)
 	fmt.Println("client-secret=" + OIDCConfig.ClientSecret)
 }


### PR DESCRIPTION
This is a first step at the issue here: https://github.com/dpastoor/wbi/issues/4

Essentially these methods convert the internal config structs and prints the various config information out to the console so users know what to add to the various config files.

There is a lot more we can do here in terms of writing/reading config files automatically. There are some packages that have a lot of features like: https://github.com/spf13/viper we could use to do more fancy parsing.

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/180123/218806953-248f2fc9-b3e7-47a1-afbb-4a260dc55ab6.png">
