### PR TITLE
Expand license activation flow to detect if active and allow skipping

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -130,13 +130,27 @@ func newSetup(setupOpts setupOpts) error {
 	WBConfig.ConfigStructToText()
 
 	// Licensing
-	licenseKey, err := license.PromptLicense()
+	licenseActivationStatus, err := license.CheckLicenseActivation()
 	if err != nil {
-		return fmt.Errorf("issue entering license key: %w", err)
+		return fmt.Errorf("issue in checking for license activation: %w", err)
 	}
-	ActivateErr := license.ActivateLicenseKey(licenseKey)
-	if ActivateErr != nil {
-		return fmt.Errorf("issue activating license key: %w", ActivateErr)
+
+	if !licenseActivationStatus {
+		licenseChoice, err := license.PromptLicenseChoice()
+		if err != nil {
+			return fmt.Errorf("issue in prompt for license activate choice: %w", err)
+		}
+
+		if licenseChoice {
+			licenseKey, err := license.PromptLicense()
+			if err != nil {
+				return fmt.Errorf("issue entering license key: %w", err)
+			}
+			ActivateErr := license.ActivateLicenseKey(licenseKey)
+			if ActivateErr != nil {
+				return fmt.Errorf("issue activating license key: %w", ActivateErr)
+			}
+		}
 	}
 
 	return nil

--- a/internal/license/detect.go
+++ b/internal/license/detect.go
@@ -1,0 +1,24 @@
+package license
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dpastoor/wbi/internal/system"
+)
+
+func CheckLicenseActivation() (bool, error) {
+
+	stdout, _, err := system.RunCommandAndCaptureOutput("sudo rstudio-server license-manager status")
+	if err != nil {
+		return false, fmt.Errorf("issue checking license activation: %w", err)
+	}
+
+	if strings.Contains(stdout, "Status: Activated") {
+		fmt.Println("\nAn active Workbench license was detected\n")
+		return true, nil
+	}
+
+	fmt.Println("\nNo active Workbench license was detected\n")
+	return false, nil
+}

--- a/internal/license/prompt.go
+++ b/internal/license/prompt.go
@@ -1,10 +1,24 @@
 package license
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 )
+
+// Prompt users if they wish to activate Workbench with a license key
+func PromptLicenseChoice() (bool, error) {
+	name := true
+	prompt := &survey.Confirm{
+		Message: "Would you like to activate Workbench with a license key?",
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with the Workbench activation prompt")
+	}
+	return name, nil
+}
 
 // Prompt users for a Workbench license key
 func PromptLicense() (string, error) {

--- a/internal/system/command.go
+++ b/internal/system/command.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,4 +25,20 @@ func RunCommand(command string) error {
 	}
 
 	return nil
+}
+
+// Runs a command in the terminal and return stdout/stderr as seperate strings
+func RunCommandAndCaptureOutput(command string) (string, string, error) {
+	cmd := exec.Command("/bin/sh", "-c", command)
+
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+
+	err := cmd.Run()
+	if err != nil {
+		return "", "", fmt.Errorf("issue running command: %w", err)
+	}
+
+	return outb.String(), errb.String(), nil
 }


### PR DESCRIPTION
Closes https://github.com/dpastoor/wbi/issues/29

The license activation flow now is as follows...

1. Detect if Workbench has an activate license already (if so then skip the rest)
2. If nothing is active, ask the user if they want to activate with a license key
3. If a user says yes, then it prompts for a license key which is then activated

![Screen Shot 2023-02-16 at 5 41 39 PM](https://user-images.githubusercontent.com/180123/219503563-d69fd7be-a3ea-49de-a001-c496b824d52b.png)
