### PR TITLE
Add to python setup

### DIFF
--- a/internal/languages/installPython.go
+++ b/internal/languages/installPython.go
@@ -148,6 +148,12 @@ func DownloadAndInstallPython(pythonVersion string, osType string) error {
 	if err != nil {
 		return fmt.Errorf("InstallPython: %w", err)
 	}
+	// Upgrade pip, setuptools, and wheel
+	err = UpgradePythonTools(pythonVersion)
+	if err != nil {
+		return fmt.Errorf("UpgradePythonTools: %w", err)
+	}
+
 	return nil
 }
 
@@ -243,6 +249,19 @@ func InstallPython(filepath string, osType string, pythonVersion string) error {
 
 	successMessage := "\nPython version " + pythonVersion + " successfully installed!\n"
 	fmt.Println(successMessage)
+	return nil
+}
+
+func UpgradePythonTools(pythonVersion string) error {
+	upgradeCommand := "/opt/python/" + pythonVersion + "/bin/pip install --upgrade pip setuptools wheel"
+	err := system.RunCommand(upgradeCommand)
+	if err != nil {
+		return fmt.Errorf("issue upgrading pip, setuptools and wheel for Python: %w", err)
+	}
+
+	successMessage := "\npip, setuptools and wheel have been upgraded for Python version " + pythonVersion + "\n"
+	fmt.Println(successMessage)
+
 	return nil
 }
 

--- a/internal/languages/installPython.go
+++ b/internal/languages/installPython.go
@@ -253,7 +253,7 @@ func InstallPython(filepath string, osType string, pythonVersion string) error {
 }
 
 func UpgradePythonTools(pythonVersion string) error {
-	upgradeCommand := "/opt/python/" + pythonVersion + "/bin/pip install --upgrade pip setuptools wheel"
+	upgradeCommand := "/opt/python/" + pythonVersion + "/bin/pip install --upgrade --no-warn-script-location --disable-pip-version-check pip setuptools wheel"
 	err := system.RunCommand(upgradeCommand)
 	if err != nil {
 		return fmt.Errorf("issue upgrading pip, setuptools and wheel for Python: %w", err)


### PR DESCRIPTION
Closes https://github.com/dpastoor/wbi/issues/19

Now after installing a version of Python into /opt/python, Workbench automatically upgrades pip, setuptools and wheel.