### PR TITLE
Add connect url prompt

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -156,11 +156,11 @@ func newSetup(setupOpts setupOpts) error {
 		return fmt.Errorf("issue in prompt for Connect URL choice: %w", err)
 	}
 	if connectChoice {
-		WBConfig.ConnectURL, err = connect.PromptConnectURL()
+		rawConnectURL, err := connect.PromptConnectURL()
 		if err != nil {
 			return fmt.Errorf("issue entering Connect URL: %w", err)
 		}
-		_, err = connect.VerifyConnectURL(WBConfig.ConnectURL)
+		WBConfig.ConnectURL, err = connect.VerifyConnectURL(rawConnectURL)
 		if err != nil {
 			return fmt.Errorf("issue with checking the Connect URL: %w", err)
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dpastoor/wbi/internal/authentication"
 	"github.com/dpastoor/wbi/internal/config"
+	"github.com/dpastoor/wbi/internal/connect"
 	"github.com/dpastoor/wbi/internal/jupyter"
 	"github.com/dpastoor/wbi/internal/languages"
 	"github.com/dpastoor/wbi/internal/license"
@@ -147,6 +148,22 @@ func newSetup(setupOpts setupOpts) error {
 	AuthErr := authentication.HandleAuthChoice(&WBConfig, osType)
 	if AuthErr != nil {
 		return fmt.Errorf("issue handling authentication: %w", AuthErr)
+	}
+
+	// Connect URL
+	connectChoice, err := connect.PromptConnectChoice()
+	if err != nil {
+		return fmt.Errorf("issue in prompt for Connect URL choice: %w", err)
+	}
+	if connectChoice {
+		WBConfig.ConnectURL, err = connect.PromptConnectURL()
+		if err != nil {
+			return fmt.Errorf("issue entering Connect URL: %w", err)
+		}
+		_, err = connect.VerifyConnectURL(WBConfig.ConnectURL)
+		if err != nil {
+			return fmt.Errorf("issue with checking the Connect URL: %w", err)
+		}
 	}
 
 	// Write config to console

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type WBConfig struct {
 	RConfig      RConfig
 	PythonConfig PythonConfig
 	AuthConfig   AuthConfig
+	ConnectURL   string
 }
 
 type AuthConfig struct {

--- a/internal/config/print.go
+++ b/internal/config/print.go
@@ -7,6 +7,7 @@ func (WBConfig *WBConfig) ConfigStructToText() {
 	WBConfig.PythonConfig.PythonStructToText()
 	WBConfig.SSLConfig.SSLStructToText()
 	WBConfig.AuthConfig.AuthStructToText()
+	WBConfig.ConnectStringToText()
 	fmt.Println("\n=== Please restart Workbench after making these changes")
 }
 
@@ -54,4 +55,10 @@ func (OIDCConfig *OIDCConfig) AuthOIDCStructToText() {
 	fmt.Println("\n=== Add to config file: /etc/rstudio/openid-client-secret:")
 	fmt.Println("client-id=" + OIDCConfig.ClientID)
 	fmt.Println("client-secret=" + OIDCConfig.ClientSecret)
+}
+
+// Prints the ConnectURL configuration string information to the console
+func (WBConfig *WBConfig) ConnectStringToText() {
+	fmt.Println("\n=== Add to config file: /etc/rstudio/rsession.conf:")
+	fmt.Println("default-rsconnect-server=" + WBConfig.ConnectURL)
 }

--- a/internal/connect/prompt.go
+++ b/internal/connect/prompt.go
@@ -1,0 +1,34 @@
+package connect
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+// Prompt users if they wish to add a default Connect URL to Workbench
+func PromptConnectChoice() (bool, error) {
+	name := true
+	prompt := &survey.Confirm{
+		Message: "Would you like to provide a default Connect URL for Workbench?",
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with the Connect URL prompt")
+	}
+	return name, nil
+}
+
+// Prompt users for a default Connect URL
+func PromptConnectURL() (string, error) {
+	target := ""
+	prompt := &survey.Input{
+		Message: "Connect URL:",
+	}
+	err := survey.AskOne(prompt, &target)
+	if err != nil {
+		return "", fmt.Errorf("issue prompting for a Connect URL: %w", err)
+	}
+	return target, nil
+}

--- a/internal/connect/verify.go
+++ b/internal/connect/verify.go
@@ -1,0 +1,63 @@
+package connect
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func cleanConnectURL(connectURL string) string {
+	// remove trailing slash if present
+	if connectURL[len(connectURL)-1] == '/' {
+		connectURL = connectURL[:len(connectURL)-1]
+	}
+	// if the url does not contain :// then add it, either http if port 3939 or https in other cases (most installs)
+	if !strings.Contains(connectURL, "://") {
+		if strings.Contains(connectURL, ":3939") {
+			connectURL = "http://" + connectURL
+		} else {
+			connectURL = "https://" + connectURL
+		}
+	}
+	return connectURL
+}
+
+// Information is only needed to check if the URL is valid
+type ProhibitedUsernames struct {
+	ProhibitedUsernames []string `json:"prohibited_usernames"`
+}
+
+// VerifyConnectURL checks if the Connect URL is valid
+func VerifyConnectURL(connectURL string) (ProhibitedUsernames, error) {
+
+	fullTestURL := cleanConnectURL(connectURL) + "/__api__/server_settings"
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, fullTestURL, nil)
+	if err != nil {
+		return ProhibitedUsernames{}, errors.New("error creating request")
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return ProhibitedUsernames{}, errors.New("error retrieving JSON data")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ProhibitedUsernames{}, errors.New("error in HTTP status code")
+	}
+	var prohibitedUsernames ProhibitedUsernames
+	err = json.NewDecoder(res.Body).Decode(&prohibitedUsernames)
+	if err != nil {
+		return ProhibitedUsernames{}, errors.New("error unmarshalling JSON data")
+	}
+
+	fmt.Println("\nConnect URL has been successfull validated.\n")
+	return prohibitedUsernames, nil
+}

--- a/internal/connect/verify.go
+++ b/internal/connect/verify.go
@@ -32,9 +32,10 @@ type ProhibitedUsernames struct {
 }
 
 // VerifyConnectURL checks if the Connect URL is valid
-func VerifyConnectURL(connectURL string) (ProhibitedUsernames, error) {
+func VerifyConnectURL(connectURL string) (string, error) {
 
-	fullTestURL := cleanConnectURL(connectURL) + "/__api__/server_settings"
+	cleanConnectURL := cleanConnectURL(connectURL)
+	fullTestURL := cleanConnectURL + "/__api__/server_settings"
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -42,22 +43,22 @@ func VerifyConnectURL(connectURL string) (ProhibitedUsernames, error) {
 	req, err := http.NewRequestWithContext(context.Background(),
 		http.MethodGet, fullTestURL, nil)
 	if err != nil {
-		return ProhibitedUsernames{}, errors.New("error creating request")
+		return "", errors.New("error creating request")
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return ProhibitedUsernames{}, errors.New("error retrieving JSON data")
+		return "", errors.New("error retrieving JSON data")
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return ProhibitedUsernames{}, errors.New("error in HTTP status code")
+		return "", errors.New("error in HTTP status code")
 	}
 	var prohibitedUsernames ProhibitedUsernames
 	err = json.NewDecoder(res.Body).Decode(&prohibitedUsernames)
 	if err != nil {
-		return ProhibitedUsernames{}, errors.New("error unmarshalling JSON data")
+		return "", errors.New("error unmarshalling JSON data")
 	}
 
 	fmt.Println("\nConnect URL has been successfull validated.\n")
-	return prohibitedUsernames, nil
+	return cleanConnectURL, nil
 }

--- a/internal/connect/verify.go
+++ b/internal/connect/verify.go
@@ -2,7 +2,6 @@ package connect
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -26,16 +25,11 @@ func cleanConnectURL(connectURL string) string {
 	return connectURL
 }
 
-// Information is only needed to check if the URL is valid
-type ProhibitedUsernames struct {
-	ProhibitedUsernames []string `json:"prohibited_usernames"`
-}
-
 // VerifyConnectURL checks if the Connect URL is valid
 func VerifyConnectURL(connectURL string) (string, error) {
 
 	cleanConnectURL := cleanConnectURL(connectURL)
-	fullTestURL := cleanConnectURL + "/__api__/server_settings"
+	fullTestURL := cleanConnectURL + "/__ping__"
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -52,11 +46,6 @@ func VerifyConnectURL(connectURL string) (string, error) {
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return "", errors.New("error in HTTP status code")
-	}
-	var prohibitedUsernames ProhibitedUsernames
-	err = json.NewDecoder(res.Body).Decode(&prohibitedUsernames)
-	if err != nil {
-		return "", errors.New("error unmarshalling JSON data")
 	}
 
 	fmt.Println("\nConnect URL has been successfull validated.\n")

--- a/internal/connect/verify.go
+++ b/internal/connect/verify.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -13,14 +12,6 @@ func cleanConnectURL(connectURL string) string {
 	// remove trailing slash if present
 	if connectURL[len(connectURL)-1] == '/' {
 		connectURL = connectURL[:len(connectURL)-1]
-	}
-	// if the url does not contain :// then add it, either http if port 3939 or https in other cases (most installs)
-	if !strings.Contains(connectURL, "://") {
-		if strings.Contains(connectURL, ":3939") {
-			connectURL = "http://" + connectURL
-		} else {
-			connectURL = "https://" + connectURL
-		}
 	}
 	return connectURL
 }


### PR DESCRIPTION
Closes https://github.com/dpastoor/wbi/issues/22

This PR adds the following prompts:

1. Ask users if they want to enter a default Connect URL
2. If yes, then asks users to enter a URL
3. The URL is cleaned and validated

The validation was a bit tricky here but in the end used the health check __ping__ endpoint to ensure the address is correct. The verify code cleans up the URL first (removes a trailing slash, if not http/https adds it) and then verifies a good success code.

Video below

https://user-images.githubusercontent.com/180123/219785733-efddb0f2-7ed0-4ff2-a277-72fdb18d0e5f.mov


