### PR TITLE
Add package manager url prompts

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dpastoor/wbi/internal/languages"
 	"github.com/dpastoor/wbi/internal/license"
 	"github.com/dpastoor/wbi/internal/os"
+	"github.com/dpastoor/wbi/internal/packagemanager"
 	"github.com/dpastoor/wbi/internal/prodrivers"
 	"github.com/dpastoor/wbi/internal/ssl"
 	"github.com/dpastoor/wbi/internal/workbench"
@@ -166,6 +167,31 @@ func newSetup(setupOpts setupOpts) error {
 	AuthErr := authentication.HandleAuthChoice(&WBConfig, osType)
 	if AuthErr != nil {
 		return fmt.Errorf("issue handling authentication: %w", AuthErr)
+	}
+
+	// Package Manager URL
+	packageManagerChoice, err := packagemanager.PromptPackageManagerChoice()
+	if err != nil {
+		return fmt.Errorf("issue in prompt for Posit Package Manager URL choice: %w", err)
+	}
+	if packageManagerChoice {
+		rawPackageManagerURL, err := packagemanager.PromptPackageManagerURL()
+		if err != nil {
+			return fmt.Errorf("issue entering Posit Package Manager URL: %w", err)
+		}
+		repoPackageManager, err := packagemanager.PromptPackageManagerRepo()
+		if err != nil {
+			return fmt.Errorf("issue entering Posit Package Manager repo name: %w", err)
+		}
+
+		cleanPackageManagerURL, err := packagemanager.VerifyPackageManagerURLAndRepo(rawPackageManagerURL, repoPackageManager)
+		if err != nil {
+			return fmt.Errorf("issue with checking the Posit Package Manager URL and repo: %w", err)
+		}
+		WBConfig.PackageManagerURL, err = packagemanager.BuildPackagemanagerFullURL(cleanPackageManagerURL, repoPackageManager, osType)
+		if err != nil {
+			return fmt.Errorf("issue with creating the full Posit Package Manager URL: %w", err)
+		}
 	}
 
 	// Write config to console

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -172,7 +172,7 @@ func newSetup(setupOpts setupOpts) error {
 	// Package Manager URL
 	packageManagerChoice, err := packagemanager.PromptPackageManagerChoice()
 	if err != nil {
-		return fmt.Errorf("issue in prompt for Posit Package Manager URL choice: %w", err)
+		return fmt.Errorf("issue in prompt for Posit Package Manager choice: %w", err)
 	}
 	if packageManagerChoice {
 		rawPackageManagerURL, err := packagemanager.PromptPackageManagerURL()
@@ -191,6 +191,23 @@ func newSetup(setupOpts setupOpts) error {
 		WBConfig.PackageManagerURL, err = packagemanager.BuildPackagemanagerFullURL(cleanPackageManagerURL, repoPackageManager, osType)
 		if err != nil {
 			return fmt.Errorf("issue with creating the full Posit Package Manager URL: %w", err)
+		}
+	} else {
+		publicPackageManagerChoice, err := packagemanager.PromptPublicPackageManagerChoice()
+		if err != nil {
+			return fmt.Errorf("issue in prompt for Posit Public Package Manager choice: %w", err)
+		}
+		if publicPackageManagerChoice {
+			// validate the public package manager URL can be reached
+			_, err := packagemanager.VerifyPackageManagerURL("https://packagemanager.rstudio.com", true)
+			if err != nil {
+				return fmt.Errorf("issue with reaching the Posit Public Package Manager URL: %w", err)
+			}
+
+			WBConfig.PackageManagerURL, err = packagemanager.BuildPublicPackageManagerFullURL(osType)
+			if err != nil {
+				return fmt.Errorf("issue with creating the full Posit Public Package Manager URL: %w", err)
+			}
 		}
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -209,7 +209,8 @@ func newSetup(setupOpts setupOpts) error {
 			if err != nil {
 				return fmt.Errorf("issue with creating the full Posit Public Package Manager URL: %w", err)
 			}
-  }
+		}
+	}
 
 	connectChoice, err := connect.PromptConnectChoice()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,10 +27,11 @@ const (
 
 // WBConfig stores the entire workbench configuration
 type WBConfig struct {
-	SSLConfig    SSLConfig
-	RConfig      RConfig
-	PythonConfig PythonConfig
-	AuthConfig   AuthConfig
+	SSLConfig         SSLConfig
+	RConfig           RConfig
+	PythonConfig      PythonConfig
+	AuthConfig        AuthConfig
+	PackageManagerURL string
 }
 
 type AuthConfig struct {

--- a/internal/config/print.go
+++ b/internal/config/print.go
@@ -7,6 +7,7 @@ func (WBConfig *WBConfig) ConfigStructToText() {
 	WBConfig.PythonConfig.PythonStructToText()
 	WBConfig.SSLConfig.SSLStructToText()
 	WBConfig.AuthConfig.AuthStructToText()
+	WBConfig.PackageManagerStringToText()
 	fmt.Println("\n=== Please restart Workbench after making these changes")
 }
 
@@ -54,4 +55,10 @@ func (OIDCConfig *OIDCConfig) AuthOIDCStructToText() {
 	fmt.Println("\n=== Add to config file: /etc/rstudio/openid-client-secret:")
 	fmt.Println("client-id=" + OIDCConfig.ClientID)
 	fmt.Println("client-secret=" + OIDCConfig.ClientSecret)
+}
+
+// Prints the Package Manager URL configuration string information to the console
+func (WBConfig *WBConfig) PackageManagerStringToText() {
+	fmt.Println("\n=== Add to config file: /etc/rstudio/repos.conf:")
+	fmt.Println("CRAN=" + WBConfig.PackageManagerURL)
 }

--- a/internal/packagemanager/construct.go
+++ b/internal/packagemanager/construct.go
@@ -2,12 +2,35 @@ package packagemanager
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/dpastoor/wbi/internal/config"
 )
 
 func BuildPackagemanagerFullURL(url string, repo string, osType config.OperatingSystem) (string, error) {
+
+	osName, err := ConvertOSTypeToOSName(osType)
+	if err != nil {
+		return "", errors.New("there was an issue converting the operating system type to an os name")
+	}
+
+	fullURL := url + "/" + repo + "/__linux__/" + osName + "/" + "latest"
+
+	return fullURL, nil
+}
+
+func BuildPublicPackageManagerFullURL(osType config.OperatingSystem) (string, error) {
+
+	osName, err := ConvertOSTypeToOSName(osType)
+	if err != nil {
+		return "", errors.New("there was an issue converting the operating system type to an os name")
+	}
+
+	fullURL := "https://packagemanager.rstudio.com/cran/__linux__/" + osName + "/" + "latest"
+
+	return fullURL, nil
+}
+
+func ConvertOSTypeToOSName(osType config.OperatingSystem) (string, error) {
 	var osName string
 	switch osType {
 	case config.Ubuntu18:
@@ -24,7 +47,5 @@ func BuildPackagemanagerFullURL(url string, repo string, osType config.Operating
 		return "", errors.New("operating system not supported")
 	}
 
-	fullURL := url + "/" + strings.ToLower(repo) + "/__linux__/" + osName + "/" + "latest"
-
-	return fullURL, nil
+	return osName, nil
 }

--- a/internal/packagemanager/construct.go
+++ b/internal/packagemanager/construct.go
@@ -1,0 +1,30 @@
+package packagemanager
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/dpastoor/wbi/internal/config"
+)
+
+func BuildPackagemanagerFullURL(url string, repo string, osType config.OperatingSystem) (string, error) {
+	var osName string
+	switch osType {
+	case config.Ubuntu18:
+		osName = "bionic"
+	case config.Ubuntu20:
+		osName = "focal"
+	case config.Ubuntu22:
+		osName = "jammy"
+	case config.Redhat7:
+		osName = "centos7"
+	case config.Redhat8:
+		osName = "centos8"
+	default:
+		return "", errors.New("operating system not supported")
+	}
+
+	fullURL := url + "/" + strings.ToLower(repo) + "/__linux__/" + osName + "/" + "latest"
+
+	return fullURL, nil
+}

--- a/internal/packagemanager/prompt.go
+++ b/internal/packagemanager/prompt.go
@@ -11,11 +11,11 @@ import (
 func PromptPackageManagerChoice() (bool, error) {
 	name := true
 	prompt := &survey.Confirm{
-		Message: "Would you like to provide a default Posit Package Manager URL for Workbench?",
+		Message: "Would you like to setup Posit Package Manager as the default CRAN repo in Workbench? You will need connectivity to the Package Manager server to use this option.",
 	}
 	err := survey.AskOne(prompt, &name)
 	if err != nil {
-		return false, errors.New("there was an issue with the Posit Package Manager URL prompt")
+		return false, errors.New("there was an issue with the Posit Package Manager choice prompt")
 	}
 	return name, nil
 }
@@ -44,4 +44,17 @@ func PromptPackageManagerRepo() (string, error) {
 		return "", fmt.Errorf("issue prompting for a Posit Package Manager repo: %w", err)
 	}
 	return target, nil
+}
+
+// Prompt users if they wish to add Posit Public Package Manager as the default CRAN repo in Workbench
+func PromptPublicPackageManagerChoice() (bool, error) {
+	name := true
+	prompt := &survey.Confirm{
+		Message: "Would you like to setup Posit Public Package Manager as the default CRAN repo in Workbench? You will need internet accessibility to use this option.",
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with the Posit Public Package Manager choice prompt")
+	}
+	return name, nil
 }

--- a/internal/packagemanager/prompt.go
+++ b/internal/packagemanager/prompt.go
@@ -1,0 +1,47 @@
+package packagemanager
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+// Prompt users if they wish to add a default Posit Package Manager URL to Workbench
+func PromptPackageManagerChoice() (bool, error) {
+	name := true
+	prompt := &survey.Confirm{
+		Message: "Would you like to provide a default Posit Package Manager URL for Workbench?",
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with the Posit Package Manager URL prompt")
+	}
+	return name, nil
+}
+
+// Prompt users for a default Posit Package Manager URL
+func PromptPackageManagerURL() (string, error) {
+	target := ""
+	prompt := &survey.Input{
+		Message: "Enter your Posit Package Manager base URL (for example, https://exampleaddress.com):",
+	}
+	err := survey.AskOne(prompt, &target)
+	if err != nil {
+		return "", fmt.Errorf("issue prompting for a Posit Package Manager URL: %w", err)
+	}
+	return target, nil
+}
+
+// Prompt users for a Posit Package Manager repo name
+func PromptPackageManagerRepo() (string, error) {
+	target := ""
+	prompt := &survey.Input{
+		Message: "Enter the name of your CRAN repository on Posit Package Manager (for example, prod-cran):",
+	}
+	err := survey.AskOne(prompt, &target)
+	if err != nil {
+		return "", fmt.Errorf("issue prompting for a Posit Package Manager repo: %w", err)
+	}
+	return target, nil
+}

--- a/internal/packagemanager/verify.go
+++ b/internal/packagemanager/verify.go
@@ -23,9 +23,9 @@ func cleanPackageManagerURL(packageManagerURL string) string {
 
 // VerifyPackageManagerURLAndRepo checks if the Posit Package Manager URL and repo is valid
 func VerifyPackageManagerURLAndRepo(packageManagerURL string, packageManagerRepo string) (string, error) {
-	cleanPackageManagerURL, err := VerifyPackageManagerURL(packageManagerURL)
+	cleanPackageManagerURL, err := VerifyPackageManagerURL(packageManagerURL, false)
 	if err != nil {
-		return "", fmt.Errorf("issue with checking the Posit Package Manager URL: %w", err)
+		return "", fmt.Errorf("issue with reaching the Posit Package Manager URL: %w", err)
 	}
 	cleanPackageManagerRepoURL, err := VerifyPackageManagerRepo(cleanPackageManagerURL, packageManagerRepo)
 	if err != nil {
@@ -34,7 +34,7 @@ func VerifyPackageManagerURLAndRepo(packageManagerURL string, packageManagerRepo
 	return cleanPackageManagerRepoURL, nil
 }
 
-func VerifyPackageManagerURL(packageManagerURL string) (string, error) {
+func VerifyPackageManagerURL(packageManagerURL string, public bool) (string, error) {
 	cleanPackageManagerURL := cleanPackageManagerURL(packageManagerURL)
 	fullTestURL := cleanPackageManagerURL + "/__ping__"
 
@@ -55,7 +55,12 @@ func VerifyPackageManagerURL(packageManagerURL string) (string, error) {
 		return "", errors.New("error in HTTP status code")
 	}
 
-	fmt.Println("\nPosit Package Manager URL has been successfull validated.\n")
+	if public {
+		fmt.Println("\nPosit Public Package Manager URL has been successfull validated.\n")
+	} else {
+		fmt.Println("\nPosit Package Manager URL has been successfull validated.\n")
+	}
+
 	return cleanPackageManagerURL, nil
 }
 


### PR DESCRIPTION
Closes https://github.com/dpastoor/wbi/issues/20

This PR add support for users adding a default CRAN repo for Workbench pointed to either their own Posit Package Manager or Posit Public Package Manager.

1. Ask the user if they would like to make PPM their default CRAN repo
2. If yes, ask for the base url
3. Ask for the repo name
4. First the based URL is checked for connectivity/correctness, then the repo name is searched via the PPM API to verify it exists
5. Once the checks have past wbi outputs the correct config file in /etc/rstudio/repos.conf
6. If the user says no to step 1 then it asks them if they would like to setup PPPM
7. If they say yes to PPPM then it validates connectivity to the server
8. Once the checks have past wbi outputs the correct config file in /etc/rstudio/repos.conf

Video below (shows first adding Posit Package Manager and then adding Posit Public Package Manager)

https://user-images.githubusercontent.com/180123/219811322-1199a818-23a7-4239-a671-8d0bc7ce6a18.mov

