### PR TITLE
Add the ability to write automatically to config files

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -240,9 +240,33 @@ func newSetup(setupOpts setupOpts) error {
 		}
 	}
 
-	// Write config to console
-	WBConfig.ConfigStructToText()
+	// Config
+	// first check if there are any config changes needed
+	configChangesNeeded := WBConfig.DetectConfigChange()
+	if configChangesNeeded {
+		// print out the changes needed
+		fmt.Println("\n=== The following configuration changes are needed:")
+		WBConfig.ConfigStructToText()
+		// ask the user if they want to write the config automatically
+		configWriteChoice, err := config.PromptWriteConfig()
+		if err != nil {
+			return fmt.Errorf("issue selecting if config changes are to be written: %w", err)
+		}
+		if configWriteChoice {
+			err := config.WriteConfig(WBConfig)
+			if err != nil {
+				return fmt.Errorf("issue writing config: %w", err)
+			}
+			err = workbench.RestartRStudioServerAndLauncher()
+			if err != nil {
+				return fmt.Errorf("issue restarting RStudio Server and Launcher: %w", err)
+			}
+		}
+	} else {
+		fmt.Println("\n=== No configuration changes are needed")
+	}
 
+	fmt.Println("\nThanks for using wbi! Please remember to make any needed manual configuration changes and restart RStudio Server and Launcher.")
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type WBConfig struct {
 	AuthConfig           AuthConfig
 	PackageManagerConfig PackageManagerConfig
 	ConnectConfig        ConnectConfig
+	ConfigChange         bool
 }
 
 type AuthConfig struct {

--- a/internal/config/detect.go
+++ b/internal/config/detect.go
@@ -1,0 +1,22 @@
+package config
+
+// Prints the WBConfig configuration struct information to the console
+func (WBConfig *WBConfig) DetectConfigChange() bool {
+	anyChange := false
+	if WBConfig.PythonConfig.JupyterPath != "" {
+		anyChange = true
+	}
+	if WBConfig.SSLConfig.UseSSL {
+		anyChange = true
+	}
+	if WBConfig.AuthConfig.Using {
+		anyChange = true
+	}
+	if WBConfig.PackageManagerConfig.Using {
+		anyChange = true
+	}
+	if WBConfig.ConnectConfig.Using {
+		anyChange = true
+	}
+	return anyChange
+}

--- a/internal/config/print.go
+++ b/internal/config/print.go
@@ -4,32 +4,22 @@ import "fmt"
 
 // Prints the WBConfig configuration struct information to the console
 func (WBConfig *WBConfig) ConfigStructToText() {
-	anyPrint := false
 	if WBConfig.PythonConfig.JupyterPath != "" {
-		anyPrint = true
 		WBConfig.PythonConfig.PythonStructToText()
 	}
 	if WBConfig.SSLConfig.UseSSL {
-		anyPrint = true
 		WBConfig.SSLConfig.SSLStructToText()
 	}
 	if WBConfig.AuthConfig.Using {
-		anyPrint = true
 		WBConfig.AuthConfig.AuthStructToText()
 	}
 	if WBConfig.PackageManagerConfig.Using {
-		anyPrint = true
 		WBConfig.PackageManagerStringToText()
 	}
 	if WBConfig.ConnectConfig.Using {
-		anyPrint = true
 		WBConfig.ConnectStringToText()
 	}
-	if anyPrint {
-		fmt.Println("\n=== Please restart Workbench after making these changes")
-	} else {
-		fmt.Println("\n=== No configuration changes are needed")
-	}
+	fmt.Println("\n=== Please restart Workbench after making these changes\n")
 }
 
 // Prints the PythonConfig configuration struct information to the console

--- a/internal/config/prompt.go
+++ b/internal/config/prompt.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+// PromptWriteConfig prompts the user if they would like the new values to be written to configuration files
+func PromptWriteConfig() (bool, error) {
+	name := true
+	prompt := &survey.Confirm{
+		Message: "The configuration changes shown above need to be written to the configuration files. Would you like wbi to write these changes and restart rstudio-server and rstudio-launcher?",
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with the config change writing prompt")
+	}
+	return name, nil
+}

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+)
+
+func WriteConfig(WBConfig WBConfig) error {
+	if WBConfig.PythonConfig.JupyterPath != "" {
+		err := WBConfig.PythonConfig.PythonStructToConfigWrite()
+		if err != nil {
+			return fmt.Errorf("failed to write python config: %w", err)
+		}
+	}
+	if WBConfig.SSLConfig.UseSSL {
+		err := WBConfig.SSLConfig.SSLStructToConfigWrite()
+		if err != nil {
+			return fmt.Errorf("failed to write SSL config: %w", err)
+		}
+	}
+	if WBConfig.AuthConfig.Using {
+		err := WBConfig.AuthConfig.AuthStructToConfigWrite()
+		if err != nil {
+			return fmt.Errorf("failed to write Authentication config: %w", err)
+		}
+	}
+	if WBConfig.PackageManagerConfig.Using {
+		err := WBConfig.PackageManagerStringToConfigWrite()
+		if err != nil {
+			return fmt.Errorf("failed to write Package Manager config: %w", err)
+		}
+	}
+	if WBConfig.ConnectConfig.Using {
+		err := WBConfig.ConnectStringToConfigWrite()
+		if err != nil {
+			return fmt.Errorf("failed to write Connect config: %w", err)
+		}
+	}
+	return nil
+}
+
+func WriteStrings(lines []string, filepath string) error {
+	file, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+
+	datawriter := bufio.NewWriter(file)
+
+	for _, data := range lines {
+		_, err := datawriter.WriteString(data + "\n")
+		if err != nil {
+			return fmt.Errorf("failed to write line: %w", err)
+		}
+	}
+
+	datawriter.Flush()
+	file.Close()
+
+	return nil
+}
+
+// Prints the PythonConfig configuration struct information to the console
+func (PythonConfig *PythonConfig) PythonStructToConfigWrite() error {
+	writeLines := []string{
+		"jupyter-exe=" + PythonConfig.JupyterPath,
+	}
+	filepath := "/etc/rstudio/jupyter.conf"
+
+	fmt.Println("\n=== Writing to the file " + filepath + ":")
+	err := WriteStrings(writeLines, filepath)
+	if err != nil {
+		fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+// Prints the SSLConfig configuration struct information to the console
+func (SSLConfig *SSLConfig) SSLStructToConfigWrite() error {
+	writeLines := []string{
+		"ssl-enabled=1",
+		"ssl-certificate=" + SSLConfig.CertPath,
+		"ssl-certificate-key=" + SSLConfig.KeyPath,
+	}
+	filepath := "/etc/rstudio/rserver.conf"
+
+	fmt.Println("\n=== Writing to the file " + filepath + ":")
+	err := WriteStrings(writeLines, filepath)
+	if err != nil {
+		fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+// Prints the AuthConfig configuration struct information to the console
+func (AuthConfig *AuthConfig) AuthStructToConfigWrite() error {
+	switch AuthConfig.AuthType {
+	case SAML:
+		err := AuthConfig.SAMLConfig.AuthSAMLStructToConfigWrite()
+		if err != nil {
+			return fmt.Errorf("failed to write SAML config: %w", err)
+		}
+	case OIDC:
+		err := AuthConfig.OIDCConfig.AuthOIDCStructToConfigWrite()
+		if err != nil {
+			return fmt.Errorf("failed to write OIDC config: %w", err)
+		}
+	default:
+		return errors.New("unknown Authentication type for writing to a config")
+	}
+	return nil
+}
+
+// Prints the SAMLConfig configuration struct information to the console
+func (SAMLConfig *SAMLConfig) AuthSAMLStructToConfigWrite() error {
+	writeLines := []string{
+		"auth-saml=1",
+		"auth-saml-sp-attribute-username=" + SAMLConfig.AuthSamlSpAttributeUsername,
+		"auth-saml-metadata-url=" + SAMLConfig.AuthSamlMetadataURL,
+	}
+	filepath := "/etc/rstudio/rserver.conf"
+
+	fmt.Println("\n=== Writing to the file " + filepath + ":")
+	err := WriteStrings(writeLines, filepath)
+	if err != nil {
+		fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+// Prints the OIDCConfig configuration struct information to the console
+func (OIDCConfig *OIDCConfig) AuthOIDCStructToConfigWrite() error {
+	// rserver.conf config options
+	writeLinesRserver := []string{
+		"auth-openid=1",
+		"auth-openid-issuer=" + OIDCConfig.AuthOpenIDIssuer,
+		"auth-openid-username-claim=" + OIDCConfig.AuthOpenIDUsernameClaim,
+	}
+	filepathRserver := "/etc/rstudio/rserver.conf"
+
+	fmt.Println("\n=== Writing to the file " + filepathRserver + ":")
+	err := WriteStrings(writeLinesRserver, filepathRserver)
+	if err != nil {
+		fmt.Errorf("failed to write config: %w", err)
+	}
+
+	// openid-client-secret config options
+	writeLinesClientSecret := []string{
+		"client-id=" + OIDCConfig.ClientID,
+		"client-secret=" + OIDCConfig.ClientSecret,
+	}
+	filepathClientSecret := "/etc/rstudio/openid-client-secret"
+
+	fmt.Println("\n=== Writing to the file " + filepathClientSecret + ":")
+	err = WriteStrings(writeLinesClientSecret, filepathClientSecret)
+	if err != nil {
+		fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
+// Prints the Package Manager URL configuration string information to the console
+func (WBConfig *WBConfig) PackageManagerStringToConfigWrite() error {
+	writeLines := []string{
+		"CRAN=" + WBConfig.PackageManagerConfig.URL,
+	}
+	filepath := "/etc/rstudio/repos.conf"
+
+	fmt.Println("\n=== Writing to the file " + filepath + ":")
+	err := WriteStrings(writeLines, filepath)
+	if err != nil {
+		fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}
+
+// Prints the ConnectURL configuration string information to the console
+func (WBConfig *WBConfig) ConnectStringToConfigWrite() error {
+	writeLines := []string{
+		"default-rsconnect-server=" + WBConfig.ConnectConfig.URL,
+	}
+	filepath := "/etc/rstudio/rsession.conf"
+
+	fmt.Println("\n=== Writing to the file " + filepath + ":")
+	err := WriteStrings(writeLines, filepath)
+	if err != nil {
+		fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
+}

--- a/internal/languages/R.go
+++ b/internal/languages/R.go
@@ -110,8 +110,9 @@ func ScanAndHandleRVersions(osType config.OperatingSystem) ([]string, error) {
 		if err != nil {
 			return []string{}, fmt.Errorf("issue installing R: %w", err)
 		}
-
-		fmt.Println("\nThe following R versions have been installed: ", strings.Join(installedRVersion, ", "))
+		if len(installedRVersion) > 0 {
+			fmt.Println("\nThe following R versions have been installed: ", strings.Join(installedRVersion, ", "))
+		}
 	}
 
 	rVersions, err := ScanForRVersions()

--- a/internal/workbench/restart.go
+++ b/internal/workbench/restart.go
@@ -1,0 +1,35 @@
+package workbench
+
+import (
+	"fmt"
+
+	"github.com/dpastoor/wbi/internal/system"
+)
+
+func RestartRStudioServerAndLauncher() error {
+	err := RestartRStudioServer()
+	if err != nil {
+		return fmt.Errorf("issue restarting rstudio-server: %w", err)
+	}
+	err = RestartRStudioLauncher()
+	if err != nil {
+		return fmt.Errorf("issue restarting rstudio-launcher: %w", err)
+	}
+	return nil
+}
+
+func RestartRStudioServer() error {
+	err := system.RunCommand("sudo rstudio-server restart")
+	if err != nil {
+		return fmt.Errorf("issue restarting rstudio-server: %w", err)
+	}
+	return nil
+}
+
+func RestartRStudioLauncher() error {
+	err := system.RunCommand("sudo rstudio-launcher restart")
+	if err != nil {
+		return fmt.Errorf("issue restarting rstudio-launcher: %w", err)
+	}
+	return nil
+}

--- a/internal/workbench/verify.go
+++ b/internal/workbench/verify.go
@@ -13,7 +13,7 @@ func VerifyWorkbench() bool {
 	if err != nil {
 		return false
 	} else {
-		fmt.Println("Workbench installation detected: ", string(stdout))
+		fmt.Println("\nWorkbench installation detected: ", string(stdout))
 		return true
 	}
 }


### PR DESCRIPTION
Closes https://github.com/dpastoor/wbi/issues/45

This PR provides the functionality to detect when there are config changes and offer the option to a user to have the changes written directly to the files and have rstudio-server and rstudio-launcher restarted.

Currently this only writes new lines to existing files (if no file exists it will create it). There is NO detection of existing duplicate config settings, this is assumed to be used a fresh server.

Video below:

https://user-images.githubusercontent.com/180123/220641571-8f7f1d9a-a75a-48b8-adbb-6a92b9900065.mov


